### PR TITLE
Fix AssignRole endpoint to persist user roles

### DIFF
--- a/ClinicManagementSystem/ClinicManagement.Api/Controllers/UsersController.cs
+++ b/ClinicManagementSystem/ClinicManagement.Api/Controllers/UsersController.cs
@@ -205,6 +205,13 @@ namespace ClinicManagement.Api.Controllers
             {
                 return BadRequest($"Role '{assignRoleDto.RoleName}' not found.");
             }
+            var userRoles = _context.Set<UserRole>();
+            if (await userRoles.AnyAsync(ur => ur.UserId == id && ur.RoleId == role.Id))
+            {
+                return BadRequest($"User already has role '{assignRoleDto.RoleName}'.");
+            }
+
+            userRoles.Add(new UserRole { UserId = id, RoleId = role.Id });
 
             try
             {


### PR DESCRIPTION
## Summary
- Save user-role associations in `AssignRole` endpoint
- Prevent duplicate role assignments for a user

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689f220d9ed083338fb31f54668b5f82