### PR TITLE
Handle nullable DoctorId in Appointment DTO

### DIFF
--- a/ClinicManagementSystem/ClinicManagement.Api/Controllers/AppointmentsController.cs
+++ b/ClinicManagementSystem/ClinicManagement.Api/Controllers/AppointmentsController.cs
@@ -41,7 +41,7 @@ namespace ClinicManagement.Api.Controllers
             {
                 AppointmentId = appointment.AppointmentId,
                 PatientId = appointment.PatientId,
-                DoctorId = (int)appointment.DoctorId,
+                DoctorId = appointment.DoctorId,
                 ServiceId = appointment.ServiceId,
                 AppointmentDateTime = appointment.AppointmentDateTime,
                 Status = appointment.Status,
@@ -164,7 +164,7 @@ namespace ClinicManagement.Api.Controllers
                 {
                     AppointmentId = a.AppointmentId,
                     PatientId = a.PatientId,
-                    DoctorId = (int)a.DoctorId,
+                    DoctorId = a.DoctorId,
                     ServiceId = a.ServiceId,
                     AppointmentDateTime = a.AppointmentDateTime,
                     Status = a.Status,
@@ -598,7 +598,7 @@ namespace ClinicManagement.Api.Controllers
             {
                 AppointmentId = appointment.AppointmentId,
                 PatientId = appointment.PatientId,
-                DoctorId = (int)appointment.DoctorId,
+                DoctorId = appointment.DoctorId,
                 ServiceId = appointment.ServiceId,
                 AppointmentDateTime = appointment.AppointmentDateTime,
                 Status = appointment.Status,

--- a/ClinicManagementSystem/ClinicManagement.Api/Controllers/MedicalRecordsController.cs
+++ b/ClinicManagementSystem/ClinicManagement.Api/Controllers/MedicalRecordsController.cs
@@ -88,14 +88,12 @@ namespace ClinicManagement.Api.Controllers
                     UserId = medicalRecord.Staff.UserId,
                     IsDeleted = medicalRecord.Staff.IsDeleted
                 } : null,
-                // Use null-forgiving operator (!) as the outer ternary ensures medicalRecord.Appointment is not null here.
-                // This resolves the 'int?' to 'int' conversion error by asserting non-nullability for the compiler.
                 Appointment = medicalRecord.Appointment != null ? new AppointmentDto
                 {
                     AppointmentId = medicalRecord.Appointment.AppointmentId,
                     PatientId = medicalRecord.Appointment.PatientId,
-                    DoctorId = (int)medicalRecord.Appointment.DoctorId, // Added ! to assert non-nullability
-                    ServiceId = medicalRecord.Appointment.ServiceId, // Added ! to assert non-nullability
+                    DoctorId = medicalRecord.Appointment.DoctorId,
+                    ServiceId = medicalRecord.Appointment.ServiceId, // ServiceId remains non-nullable
                     AppointmentDateTime = medicalRecord.Appointment.AppointmentDateTime,
                     Status = medicalRecord.Appointment.Status,
                     Notes = medicalRecord.Appointment.Notes,

--- a/ClinicManagementSystem/ClinicManagement.Api/DTOs/Appointments/AppointmentDto.cs
+++ b/ClinicManagementSystem/ClinicManagement.Api/DTOs/Appointments/AppointmentDto.cs
@@ -13,7 +13,7 @@ namespace ClinicManagement.Api.DTOs.Appointments
     {
         public int AppointmentId { get; set; }
         public int? PatientId { get; set; } // Nullable as per model
-        public int DoctorId { get; set; }
+        public int? DoctorId { get; set; } // Nullable to mirror model
         public int ServiceId { get; set; }
         public DateTime AppointmentDateTime { get; set; }
         // Change from string to enum


### PR DESCRIPTION
## Summary
- Make `AppointmentDto.DoctorId` nullable to mirror model
- Map nullable doctor IDs throughout `AppointmentsController`
- Ensure `MedicalRecordsController` maps nullable doctor IDs safely

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689f2683963083339bf0bf18f012373b